### PR TITLE
fix stackoverflow Error

### DIFF
--- a/src/main/java/com/example/intermediate/domain/Member.java
+++ b/src/main/java/com/example/intermediate/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.intermediate.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class Member extends Timestamped {
   private String password;
 
   @OneToMany(mappedBy = "member",fetch = FetchType.EAGER)
+  @JsonBackReference
   private List<Post> posts;
 
   @OneToMany(mappedBy = "member",fetch = FetchType.LAZY)

--- a/src/main/java/com/example/intermediate/domain/Post.java
+++ b/src/main/java/com/example/intermediate/domain/Post.java
@@ -4,6 +4,7 @@ import com.example.intermediate.controller.request.PostRequestDto;
 import java.util.List;
 import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +35,7 @@ public class Post extends Timestamped {
 
   @JoinColumn(name = "member_id", nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
+  @JsonManagedReference
   private Member member;
 
   @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## Error 메시지

> Cannot call sendError() after the response has been committed

### 원인 
관계 설정 때문에 지속적으로 참조되는 루프 현상

### 해결방법 

  @JsonManagedReference
  @JsonBackReference
이용하여 해결 자세한건 아래 블로그 참고

### 참고 URL
https://velog.io/@youns1121/JPA-java.lang.IllegalStateException-Cannot-call-sendError-after-the-response-has-been-committed